### PR TITLE
Fix condition for incrementing r

### DIFF
--- a/testSignificance.py
+++ b/testSignificance.py
@@ -97,7 +97,7 @@ def Bootstrap(data_A, data_B, n, R):
             temp_A.append(data_A[samp])
             temp_B.append(data_B[samp])
         delta = float(sum([x - y for x, y in zip(temp_A, temp_B)])) / n
-        if (delta < 2*delta_orig):
+        if (delta > 2*delta_orig):
             r = r + 1
     pval = float(r)/(R)
     return pval


### PR DESCRIPTION
Hi,
I found a mistake in the Bootstrap implementation.
See: http://nlp.cs.berkeley.edu/pubs/BergKirkpatrick-Burkett-Klein_2012_Significance_paper.pdf

According to the Fig. 1 of the paper, the condition for incrementing r is:
```
f δ(x(i)) > 2δ(x)
```

However, the current implementation seems to set the opposite condition:
```
f δ(x(i)) < 2δ(x)
```

Cheers,